### PR TITLE
Add Pest tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,15 @@
     "craftcms/ecs": "dev-main",
     "craftcms/phpstan": "dev-main",
     "craftcms/rector": "dev-main",
+    "markhuot/craft-pest-core": "dev-patch-1",
     "nystudio107/craft-closure": "^1.0.5"
   },
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/bencroker/craft-pest-core"
+    }
+  ],
   "scripts": {
     "phpstan": "phpstan --ansi --memory-limit=1G",
     "check-cs": "ecs check --ansi",
@@ -40,6 +47,7 @@
   "config": {
     "allow-plugins": {
       "craftcms/plugin-installer": true,
+      "pestphp/pest-plugin": true,
       "yiisoft/yii2-composer": true
     },
     "optimize-autoloader": true,

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,7 @@
+# Testing
+
+## Pest Tests
+
+```shell
+php vendor/bin/pest --configuration=vendor/nystudio107/craft-twig-sandbox/tests/pest/phpunit.xml --test-directory=vendor/nystudio107/craft-twig-sandbox/tests/pest
+```

--- a/tests/pest/Architecture/ArchitectureTest.php
+++ b/tests/pest/Architecture/ArchitectureTest.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * Tests the architecture of the plugin.
+ */
+
+test('Source code does not contain any “dump or die” statements')
+    ->expect(['var_dump', 'die'])
+    ->not->toBeUsed();

--- a/tests/pest/Feature/BlacklistSecurityPolicyTest.php
+++ b/tests/pest/Feature/BlacklistSecurityPolicyTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Tests the Blacklist Security Policy.
+ */
+
+use nystudio107\crafttwigsandbox\twig\BlacklistSecurityPolicy;
+use nystudio107\crafttwigsandbox\web\SandboxView;
+use Twig\Sandbox\SecurityNotAllowedFilterError;
+use Twig\Sandbox\SecurityNotAllowedFunctionError;
+use Twig\Sandbox\SecurityNotAllowedTagError;
+
+test('Blacklisted tag is not allowed', function() {
+    $sandboxView = new SandboxView([
+        'securityPolicy' => new BlacklistSecurityPolicy([
+            'twigTags' => ['set'],
+        ]),
+    ]);
+    $sandboxView->renderString('{% set x = 1 %}');
+})->throws(SecurityNotAllowedTagError::class);
+
+test('Non blacklisted tag is allowed', function() {
+    $sandboxView = new SandboxView([
+        'securityPolicy' => new BlacklistSecurityPolicy([
+            'twigTags' => [],
+        ]),
+    ]);
+    $sandboxView->renderString('{% set x = 1 %}');
+})->throwsNoExceptions();
+
+test('Blacklisted filter is not allowed', function() {
+    $sandboxView = new SandboxView([
+        'securityPolicy' => new BlacklistSecurityPolicy([
+            'twigFilters' => ['abs'],
+        ]),
+    ]);
+    $sandboxView->renderString('{{ 6|abs }}');
+})->throws(SecurityNotAllowedFilterError::class);
+
+test('Non blacklisted filter is allowed', function() {
+    $sandboxView = new SandboxView([
+        'securityPolicy' => new BlacklistSecurityPolicy([
+            'twigFilters' => [],
+        ]),
+    ]);
+    $sandboxView->renderString('{{ 6|abs }}');
+})->throwsNoExceptions();
+
+test('Blacklisted function is not allowed', function() {
+    $sandboxView = new SandboxView([
+        'securityPolicy' => new BlacklistSecurityPolicy([
+            'twigFunctions' => ['random'],
+        ]),
+    ]);
+    $sandboxView->renderString('{{ random() }}');
+})->throws(SecurityNotAllowedFunctionError::class);
+
+test('Non blacklisted function is allowed', function() {
+    $sandboxView = new SandboxView([
+        'securityPolicy' => new BlacklistSecurityPolicy([
+            'twigFunctions' => [],
+        ]),
+    ]);
+    $sandboxView->renderString('{{ random() }}');
+})->throwsNoExceptions();

--- a/tests/pest/Feature/WhitelistSecurityPolicyTest.php
+++ b/tests/pest/Feature/WhitelistSecurityPolicyTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Tests the Whitelist Security Policy.
+ */
+
+use nystudio107\crafttwigsandbox\twig\WhitelistSecurityPolicy;
+use nystudio107\crafttwigsandbox\web\SandboxView;
+use Twig\Sandbox\SecurityNotAllowedFilterError;
+use Twig\Sandbox\SecurityNotAllowedFunctionError;
+use Twig\Sandbox\SecurityNotAllowedTagError;
+
+test('Whitelisted tag is allowed', function() {
+    $sandboxView = new SandboxView([
+        'securityPolicy' => new WhitelistSecurityPolicy([
+            'twigTags' => ['set'],
+        ]),
+    ]);
+    $sandboxView->renderString('{% set x = 1 %}');
+})->throwsNoExceptions();
+
+test('Non whitelisted tag is not allowed', function() {
+    $sandboxView = new SandboxView([
+        'securityPolicy' => new WhitelistSecurityPolicy([
+            'twigTags' => [],
+        ]),
+    ]);
+    $sandboxView->renderString('{% set x = 1 %}');
+})->throws(SecurityNotAllowedTagError::class);
+
+test('Whitelisted filter is allowed', function() {
+    $sandboxView = new SandboxView([
+        'securityPolicy' => new WhitelistSecurityPolicy([
+            'twigFilters' => ['abs'],
+        ]),
+    ]);
+    $sandboxView->renderString('{{ 6|abs }}');
+})->throwsNoExceptions();
+
+test('Non whitelisted filter is not allowed', function() {
+    $sandboxView = new SandboxView([
+        'securityPolicy' => new WhitelistSecurityPolicy([
+            'twigFilters' => [],
+        ]),
+    ]);
+    $sandboxView->renderString('{{ 6|abs }}');
+})->throws(SecurityNotAllowedFilterError::class);
+
+test('Whitelisted function is allowed', function() {
+    $sandboxView = new SandboxView([
+        'securityPolicy' => new WhitelistSecurityPolicy([
+            'twigFunctions' => ['random'],
+        ]),
+    ]);
+    $sandboxView->renderString('{{ random() }}');
+})->throwsNoExceptions();
+
+test('Non whitelisted function is not allowed', function() {
+    $sandboxView = new SandboxView([
+        'securityPolicy' => new WhitelistSecurityPolicy([
+            'twigFunctions' => [],
+        ]),
+    ]);
+    $sandboxView->renderString('{{ random() }}');
+})->throws(SecurityNotAllowedFunctionError::class);

--- a/tests/pest/Pest.php
+++ b/tests/pest/Pest.php
@@ -1,0 +1,56 @@
+<?php
+
+use craft\events\ExceptionEvent;
+use craft\web\ErrorHandler;
+use markhuot\craftpest\test\TestCase;
+use yii\base\Event;
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "uses()" function to bind a different classes or traits.
+|
+*/
+
+uses(TestCase::class)
+    ->beforeEach(function() {
+        // Ensure exceptions are thrown, so we can catch them in our tests.
+        Event::on(ErrorHandler::class, ErrorHandler::EVENT_BEFORE_HANDLE_EXCEPTION,
+            function(ExceptionEvent $event) {
+                throw $event->exception;
+            }
+        );
+    })
+    ->in('./');
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+/*
+|--------------------------------------------------------------------------
+| Constants
+|--------------------------------------------------------------------------
+*/
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/

--- a/tests/pest/phpunit.xml
+++ b/tests/pest/phpunit.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/|version|/phpunit.xsd"
+         bootstrap="/var/www/html/vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory suffix="Test.php">.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
Adds Pest tests as a starting point.

Note that https://github.com/bencroker/craft-pest-core/tree/patch-1 must be used until https://github.com/markhuot/craft-pest-core/pull/27 is merged.

![screenshot-FuitFu55@2x](https://github.com/nystudio107/craft-twig-sandbox/assets/57572400/2018efd1-8fac-4a2e-a42d-c0eff33a5a0a)